### PR TITLE
Build system

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,7 @@
 inline-quotes = double
 ignore =
     E501
+    W503
     PLC0103
     PLC0111
     PLC0112
@@ -10,6 +11,7 @@ ignore =
     PLC0116
     PLC0301
     PLR0911
+    PLE0401
 per-file-ignores =
     tests/*:S101,B011,ANN
 exclude =

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.github/workflows/generate-index.yaml
+++ b/.github/workflows/generate-index.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: generate index
         run: |
           pip install poetry
-          poetry install --no-ansi --no-interaction --no-dev
+          poetry install --no-ansi --no-interaction --without=dev
           poetry run ghpypi --output=docs --repositories=repositories.txt --token=${{ secrets.GITHUB_TOKEN }}
 
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    if: >
-      !contains(github.event.head_commit.message, 'ci skip') &&
-      !contains(github.event.pull_request.title, 'ci skip')
-
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -25,16 +21,17 @@ jobs:
         with:
           python-version: "3.10.x"
 
+      - name: linter
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: flake8 --all-files
+
       - name: build
         run: |
           pip install poetry
           poetry config virtualenvs.in-project true
-          poetry config virtualenvs.create true
           poetry install --no-ansi --no-interaction
 
-      - name: test
+      - name: tests
         run: |
-          poetry run pytest
-          poetry run pytest --isort
           poetry run pytest --mypy
-          poetry run pytest --flake8

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,8 +23,6 @@ jobs:
 
       - name: linter
         uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: flake8 --all-files
 
       - name: build
         run: |

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile=black
+src_paths=src,tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+exclude: '^$'
+fail_fast: false
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-ast
+      - id: check-case-conflict
+      - id: trailing-whitespace
+        exclude: "(^.idea/|^docs/)"
+      - id: end-of-file-fixer
+        exclude: "(^.idea/|^docs/)"
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-annotations
+          - flake8-bandit
+          - flake8-black
+          - flake8-broken-line
+          - flake8-builtins
+          - flake8-bugbear
+          - flake8-commas
+          - flake8-comprehensions
+          - flake8-isort
+          - flake8-no-implicit-concat
+          - flake8-pylint
+          - flake8-quotes
+          - flake8-simplify
+          - pep8-naming

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,18 @@ all: build
 build:
 	@echo "Nothing to build. Try 'test' instead."
 
-.PHONY: test
-test:
+.PHONY: install
+install:
+	pre-commit install
 	poetry install --no-interaction
-	poetry run pytest --flake8 --mypy --cov=src --cov-report=term --cov-report=html --log-level=ERROR -p no:warnings
+
+.PHONY: test
+test: install
+	poetry run pytest --mypy --cov=src --cov-report=term --cov-report=html
+
+.PHONY: pre-commit
+pre-commit: install
+	pre-commit run --all-files
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you want to trigger a rebuild of the PyPI repository index when another GitHu
       # leave this exactly as it is -- the values get replaced automatically
       route: POST /repos/{owner}/{repo}/actions/workflows/{workflow}/dispatches
 
-      # change this to be the name of the organization where your GitHub Pages PyPI repository exists 
+      # change this to be the name of the organization where your GitHub Pages PyPI repository exists
       owner: myorg
 
       # change this to be the name of the GitHub repository referenced above
@@ -114,9 +114,26 @@ name = "ghpypi"
 url = "https://myorg.github.io/ghpypi/simple/"
 ```
 
-## TODO
+## Development
 
-This project needs some tests.
+In order to do development on this repository you must have [poetry](https://python-poetry.org/) and [pre-commit](https://pre-commit.com/) installed. For example, if you have Homebrew installed you can run this command:
+
+```commandline
+brew install poetry pre-commit
+```
+
+After installing these, clone this project and run this commands:
+
+```commandline
+make install
+```
+
+Running that will install the pre-commit hook and set up your poetry environment. Now you can begin development. Some common development commands:
+
+```commandline
+make test  # run all tests, perform static typing checks, and generate a coverage report
+make pre-commit  # run pre-commit hooks (i.e. black, isort, and flake8) before committing
+```
 
 ## Credits
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,25 +1,4 @@
 [[package]]
-name = "astor"
-version = "0.8.1"
-description = "Read/rewrite/write Python ASTs"
-category = "dev"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-
-[[package]]
-name = "astroid"
-version = "2.11.7"
-description = "An abstract syntax tree for Python with inference support."
-category = "dev"
-optional = false
-python-versions = ">=3.6.2"
-
-[package.dependencies]
-lazy-object-proxy = ">=1.4.0"
-typing-extensions = {version = ">=3.10", markers = "python_version < \"3.10\""}
-wrapt = ">=1.11,<2"
-
-[[package]]
 name = "atomicwrites"
 version = "1.4.1"
 description = "Atomic file writes."
@@ -36,33 +15,14 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-tests_no_zope = ["cloudpickle", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-tests = ["cloudpickle", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-docs = ["sphinx-notfound-page", "zope.interface", "sphinx", "furo"]
-dev = ["cloudpickle", "pre-commit", "sphinx-notfound-page", "sphinx", "furo", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-
-[[package]]
-name = "bandit"
-version = "1.7.4"
-description = "Security oriented static analyser for python code."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
-GitPython = ">=1.0.1"
-PyYAML = ">=5.3.1"
-stevedore = ">=1.20.0"
-
-[package.extras]
-yaml = ["pyyaml"]
-toml = ["toml"]
-test = ["pylint (==1.9.4)", "beautifulsoup4 (>=4.8.0)", "toml", "testtools (>=2.3.0)", "testscenarios (>=0.5.0)", "stestr (>=2.5.0)", "flake8 (>=4.0.0)", "fixtures (>=3.0.0)", "coverage (>=4.5.4)"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.9.24"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -81,14 +41,14 @@ pycparser = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.1.0"
+version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "colorama"
@@ -100,7 +60,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.4.3"
+version = "6.5.0"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -124,22 +84,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 wrapt = ">=1.10,<2"
 
 [package.extras]
-dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
-
-[[package]]
-name = "dill"
-version = "0.3.5.1"
-description = "serialize all of python"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
-
-[package.extras]
-graph = ["objgraph (>=1.7.2)"]
+dev = ["PyTest", "PyTest (<5)", "PyTest-Cov", "PyTest-Cov (<2.6)", "bump2version (<1)", "configparser (<5)", "importlib-metadata (<3)", "importlib-resources (<4)", "sphinx (<2)", "sphinxcontrib-websupport (<2)", "tox", "zipp (<2)"]
 
 [[package]]
 name = "distlib"
-version = "0.3.5"
+version = "0.3.6"
 description = "Distribution utilities"
 category = "main"
 optional = false
@@ -158,195 +107,8 @@ docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1
 testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
-name = "flake8"
-version = "5.0.4"
-description = "the modular source code checker: pep8 pyflakes and co"
-category = "dev"
-optional = false
-python-versions = ">=3.6.1"
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.9.0,<2.10.0"
-pyflakes = ">=2.5.0,<2.6.0"
-
-[[package]]
-name = "flake8-annotations"
-version = "2.9.1"
-description = "Flake8 Type Annotation Checks"
-category = "dev"
-optional = false
-python-versions = ">=3.7,<4.0"
-
-[package.dependencies]
-attrs = ">=21.4"
-flake8 = ">=3.7"
-
-[[package]]
-name = "flake8-bandit"
-version = "3.0.0"
-description = "Automated security testing with bandit and flake8."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-bandit = ">=1.7.3"
-flake8 = "*"
-flake8-polyfill = "*"
-pycodestyle = "*"
-
-[[package]]
-name = "flake8-broken-line"
-version = "0.5.0"
-description = "Flake8 plugin to forbid backslashes for line breaks"
-category = "dev"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[package.dependencies]
-flake8 = ">=3.5,<6"
-
-[[package]]
-name = "flake8-bugbear"
-version = "22.7.1"
-description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-attrs = ">=19.2.0"
-flake8 = ">=3.0.0"
-
-[package.extras]
-dev = ["pre-commit", "hypothesmith (>=0.2)", "hypothesis", "coverage"]
-
-[[package]]
-name = "flake8-builtins"
-version = "1.5.3"
-description = "Check for python builtins being used as variables or parameters."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-flake8 = "*"
-
-[package.extras]
-test = ["coverage", "coveralls", "mock", "pytest", "pytest-cov"]
-
-[[package]]
-name = "flake8-commas"
-version = "2.1.0"
-description = "Flake8 lint for trailing commas."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-flake8 = ">=2"
-
-[[package]]
-name = "flake8-comprehensions"
-version = "3.10.0"
-description = "A flake8 plugin to help you write better list/set/dict comprehensions."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-flake8 = ">=3.0,<3.2.0 || >3.2.0"
-
-[[package]]
-name = "flake8-no-implicit-concat"
-version = "0.3.3"
-description = "Flake8 plugin that forbids implicit str/bytes literal concatenations"
-category = "dev"
-optional = false
-python-versions = ">=3.3"
-
-[package.dependencies]
-flake8 = "*"
-more-itertools = {version = "*", markers = "python_version < \"3.10\""}
-
-[package.extras]
-dev = ["codecov", "coverage", "mypy", "darglint", "flake8-rst-docstrings", "flake8-docstrings", "flake8-2020", "flake8-builtins", "flake8-broken-line", "pep8-naming", "flake8-isort", "flake8-black", "hacking (>=4)", "flake8", "isort", "black"]
-
-[[package]]
-name = "flake8-polyfill"
-version = "1.0.2"
-description = "Polyfill package for Flake8 plugins"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-flake8 = "*"
-
-[[package]]
-name = "flake8-pylint"
-version = "0.1.3"
-description = "Flake8 plugin that runs PyLint."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-flake8 = "*"
-pylint = "*"
-
-[package.extras]
-dev = ["pytest", "mypy", "isort"]
-
-[[package]]
-name = "flake8-quotes"
-version = "3.3.1"
-description = "Flake8 lint for quotes."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-flake8 = "*"
-
-[[package]]
-name = "flake8-simplify"
-version = "0.19.3"
-description = "flake8 plugin which checks for code that can be simplified"
-category = "dev"
-optional = false
-python-versions = ">=3.6.1"
-
-[package.dependencies]
-astor = ">=0.1"
-flake8 = ">=3.7"
-
-[[package]]
-name = "gitdb"
-version = "4.0.9"
-description = "Git Object Database"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-smmap = ">=3.0.1,<6"
-
-[[package]]
-name = "gitpython"
-version = "3.1.27"
-description = "GitPython is a python library used to interact with Git repositories"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-gitdb = ">=4.0.1,<5"
-
-[[package]]
 name = "idna"
-version = "3.3"
+version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
@@ -359,20 +121,6 @@ description = "iniconfig: brain-dead simple config-ini parsing"
 category = "dev"
 optional = false
 python-versions = "*"
-
-[[package]]
-name = "isort"
-version = "5.10.1"
-description = "A Python utility / library to sort Python imports."
-category = "dev"
-optional = false
-python-versions = ">=3.6.1,<4.0"
-
-[package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
-plugins = ["setuptools"]
 
 [[package]]
 name = "jinja2"
@@ -389,14 +137,6 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
-name = "lazy-object-proxy"
-version = "1.7.1"
-description = "A fast and thorough lazy object proxy."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
 name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -405,28 +145,12 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
-name = "more-itertools"
-version = "8.14.0"
-description = "More routines for operating on iterables, beyond itertools"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-
-[[package]]
 name = "mypy"
-version = "0.971"
+version = "0.982"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3"
@@ -434,9 +158,9 @@ tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
-reports = ["lxml"]
-python2 = ["typed-ast (>=1.4.0,<2)"]
 dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
@@ -458,37 +182,6 @@ python-versions = ">=3.6"
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
-name = "pbr"
-version = "5.10.0"
-description = "Python Build Reasonableness"
-category = "dev"
-optional = false
-python-versions = ">=2.6"
-
-[[package]]
-name = "pep8-naming"
-version = "0.13.1"
-description = "Check PEP-8 naming conventions, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-flake8 = ">=3.9.1"
-
-[[package]]
-name = "platformdirs"
-version = "2.5.2"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.extras]
-test = ["pytest (>=6)", "pytest-mock (>=3.6)", "pytest-cov (>=2.7)", "appdirs (==1.4.4)"]
-docs = ["sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)", "proselint (>=0.10.2)", "furo (>=2021.7.5b38)"]
-
-[[package]]
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
@@ -497,8 +190,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
@@ -509,14 +202,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "pycodestyle"
-version = "2.9.1"
-description = "Python style guide checker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -525,16 +210,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "pyflakes"
-version = "2.5.0"
-description = "passive checker of Python programs"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
 name = "pygithub"
-version = "1.55"
+version = "1.56"
 description = "Use the full Github API v3"
 category = "main"
 optional = false
@@ -551,40 +228,17 @@ integrations = ["cryptography"]
 
 [[package]]
 name = "pyjwt"
-version = "2.4.0"
+version = "2.5.0"
 description = "JSON Web Token implementation in Python"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
-crypto = ["cryptography (>=3.3.1)"]
-dev = ["sphinx", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "mypy", "pre-commit"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
-
-[[package]]
-name = "pylint"
-version = "2.14.5"
-description = "python code static checker"
-category = "dev"
-optional = false
-python-versions = ">=3.7.2"
-
-[package.dependencies]
-astroid = ">=2.11.6,<=2.12.0-dev0"
-colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-dill = ">=0.2"
-isort = ">=4.2.5,<6"
-mccabe = ">=0.6,<0.8"
-platformdirs = ">=2.2.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-tomlkit = ">=0.10.1"
-typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-spelling = ["pyenchant (>=3.2,<4.0)"]
-testutils = ["gitpython (>3)"]
+crypto = ["cryptography (>=3.3.1)", "types-cryptography (>=3.3.21)"]
+dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.3.1)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "types-cryptography (>=3.3.21)", "zope.interface"]
+docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pynacl"
@@ -598,8 +252,8 @@ python-versions = ">=3.6"
 cffi = ">=1.4.1"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
-tests = ["pytest (>=3.2.1,!=3.3.0)", "hypothesis (>=3.27.0)"]
+docs = ["sphinx (>=1.6.5)", "sphinx_rtd_theme"]
+tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
 name = "pyparsing"
@@ -614,14 +268,13 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.1.2"
+version = "7.1.3"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 iniconfig = "*"
@@ -631,11 +284,11 @@ py = ">=1.8.2"
 tomli = ">=1.0.0"
 
 [package.extras]
-testing = ["xmlschema", "requests", "pygments (>=2.7.2)", "nose", "mock", "hypothesis (>=3.56)", "argcomplete"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
-version = "3.0.0"
+version = "4.0.0"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
@@ -646,35 +299,11 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["virtualenv", "pytest-xdist", "six", "process-tests", "hunter", "fields"]
-
-[[package]]
-name = "pytest-flake8"
-version = "1.1.1"
-description = "pytest plugin to check FLAKE8 requirements"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-flake8 = ">=4.0"
-pytest = ">=7.0"
-
-[[package]]
-name = "pytest-isort"
-version = "3.0.0"
-description = "py.test plugin to check import ordering using isort"
-category = "dev"
-optional = false
-python-versions = ">=3.6,<4"
-
-[package.dependencies]
-isort = ">=4.0"
-pytest = ">=5.0"
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
 name = "pytest-mock"
-version = "3.8.2"
+version = "3.10.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 category = "dev"
 optional = false
@@ -684,15 +313,15 @@ python-versions = ">=3.7"
 pytest = ">=5.0"
 
 [package.extras]
-dev = ["pytest-asyncio", "tox", "pre-commit"]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "pytest-mypy"
-version = "0.9.1"
+version = "0.10.0"
 description = "Mypy static type checker plugin for Pytest"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 attrs = ">=19.0"
@@ -705,14 +334,6 @@ pytest = [
     {version = ">=4.6", markers = "python_version >= \"3.6\" and python_version < \"3.10\""},
     {version = ">=6.2", markers = "python_version >= \"3.10\""},
 ]
-
-[[package]]
-name = "pyyaml"
-version = "6.0"
-description = "YAML parser and emitter for Python"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
 
 [[package]]
 name = "requests"
@@ -729,42 +350,33 @@ idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "responses"
-version = "0.21.0"
+version = "0.22.0"
 description = "A utility library for mocking out the `requests` Python library."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-requests = ">=2.0,<3.0"
+requests = ">=2.22.0,<3.0"
+toml = "*"
+types-toml = "*"
 urllib3 = ">=1.25.10"
 
 [package.extras]
-tests = ["pytest (>=7.0.0)", "coverage (>=6.0.0)", "pytest-cov", "pytest-asyncio", "pytest-localserver", "flake8", "types-mock", "types-requests", "mypy"]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "types-requests"]
 
 [[package]]
-name = "smmap"
-version = "5.0.0"
-description = "A pure Python implementation of a sliding window memory map manager"
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
-
-[[package]]
-name = "stevedore"
-version = "4.0.0"
-description = "Manage dynamic plugins for Python applications"
-category = "dev"
-optional = false
-python-versions = ">=3.8"
-
-[package.dependencies]
-pbr = ">=2.0.0,<2.1.0 || >2.1.0"
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
@@ -775,16 +387,8 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
-name = "tomlkit"
-version = "0.11.3"
-description = "Style preserving TOML library"
-category = "dev"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[[package]]
 name = "types-atomicwrites"
-version = "1.4.5"
+version = "1.4.5.1"
 description = "Typing stubs for atomicwrites"
 category = "dev"
 optional = false
@@ -792,7 +396,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-requests"
-version = "2.28.8"
+version = "2.28.11.2"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -802,8 +406,16 @@ python-versions = "*"
 types-urllib3 = "<1.27"
 
 [[package]]
+name = "types-toml"
+version = "0.10.8"
+description = "Typing stubs for toml"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "types-urllib3"
-version = "1.26.22"
+version = "1.26.25.1"
 description = "Typing stubs for urllib3"
 category = "dev"
 optional = false
@@ -811,7 +423,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "dev"
 optional = false
@@ -819,16 +431,16 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.11"
+version = "1.26.12"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
-secure = ["ipaddress", "certifi", "idna (>=2.0.0)", "cryptography (>=1.3.4)", "pyOpenSSL (>=0.14)"]
-brotli = ["brotlipy (>=0.6.0)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
 
 [[package]]
 name = "wrapt"
@@ -841,78 +453,401 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "35e23424f2717b38518b4341c89bde626dea2077890c6962710fac3b7d3395ae"
+content-hash = "aed8dbee0a8b83673d0372ab6b92d1a59f1d60fc088f922c58deca323001927b"
 
 [metadata.files]
-astor = []
-astroid = []
-atomicwrites = []
-attrs = []
-bandit = []
-certifi = []
-cffi = []
-charset-normalizer = []
-colorama = []
-coverage = []
-deprecated = []
-dill = []
-distlib = []
-filelock = []
-flake8 = []
-flake8-annotations = []
-flake8-bandit = []
-flake8-broken-line = []
-flake8-bugbear = []
-flake8-builtins = []
-flake8-commas = []
-flake8-comprehensions = []
-flake8-no-implicit-concat = []
-flake8-polyfill = []
-flake8-pylint = []
-flake8-quotes = []
-flake8-simplify = []
-gitdb = []
-gitpython = []
-idna = []
-iniconfig = []
-isort = []
-jinja2 = []
-lazy-object-proxy = []
-markupsafe = []
-mccabe = []
-more-itertools = []
-mypy = []
-mypy-extensions = []
-packaging = []
-pbr = []
-pep8-naming = []
-platformdirs = []
-pluggy = []
-py = []
-pycodestyle = []
-pycparser = []
-pyflakes = []
-pygithub = []
-pyjwt = []
-pylint = []
-pynacl = []
-pyparsing = []
-pytest = []
-pytest-cov = []
-pytest-flake8 = []
-pytest-isort = []
-pytest-mock = []
-pytest-mypy = []
-pyyaml = []
-requests = []
-responses = []
-smmap = []
-stevedore = []
-tomli = []
-tomlkit = []
-types-atomicwrites = []
-types-requests = []
-types-urllib3 = []
-typing-extensions = []
-urllib3 = []
-wrapt = []
+atomicwrites = [
+    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
+]
+attrs = [
+    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
+    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
+]
+certifi = [
+    {file = "certifi-2022.9.24-py3-none-any.whl", hash = "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"},
+    {file = "certifi-2022.9.24.tar.gz", hash = "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14"},
+]
+cffi = [
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
+    {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
+]
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+coverage = [
+    {file = "coverage-6.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef8674b0ee8cc11e2d574e3e2998aea5df5ab242e012286824ea3c6970580e53"},
+    {file = "coverage-6.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:784f53ebc9f3fd0e2a3f6a78b2be1bd1f5575d7863e10c6e12504f240fd06660"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4a5be1748d538a710f87542f22c2cad22f80545a847ad91ce45e77417293eb4"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83516205e254a0cb77d2d7bb3632ee019d93d9f4005de31dca0a8c3667d5bc04"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af4fffaffc4067232253715065e30c5a7ec6faac36f8fc8d6f64263b15f74db0"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:97117225cdd992a9c2a5515db1f66b59db634f59d0679ca1fa3fe8da32749cae"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a1170fa54185845505fbfa672f1c1ab175446c887cce8212c44149581cf2d466"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:11b990d520ea75e7ee8dcab5bc908072aaada194a794db9f6d7d5cfd19661e5a"},
+    {file = "coverage-6.5.0-cp310-cp310-win32.whl", hash = "sha256:5dbec3b9095749390c09ab7c89d314727f18800060d8d24e87f01fb9cfb40b32"},
+    {file = "coverage-6.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:59f53f1dc5b656cafb1badd0feb428c1e7bc19b867479ff72f7a9dd9b479f10e"},
+    {file = "coverage-6.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4a5375e28c5191ac38cca59b38edd33ef4cc914732c916f2929029b4bfb50795"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4ed2820d919351f4167e52425e096af41bfabacb1857186c1ea32ff9983ed75"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:33a7da4376d5977fbf0a8ed91c4dffaaa8dbf0ddbf4c8eea500a2486d8bc4d7b"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8fb6cf131ac4070c9c5a3e21de0f7dc5a0fbe8bc77c9456ced896c12fcdad91"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a6b7d95969b8845250586f269e81e5dfdd8ff828ddeb8567a4a2eaa7313460c4"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1ef221513e6f68b69ee9e159506d583d31aa3567e0ae84eaad9d6ec1107dddaa"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cca4435eebea7962a52bdb216dec27215d0df64cf27fc1dd538415f5d2b9da6b"},
+    {file = "coverage-6.5.0-cp311-cp311-win32.whl", hash = "sha256:98e8a10b7a314f454d9eff4216a9a94d143a7ee65018dd12442e898ee2310578"},
+    {file = "coverage-6.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:bc8ef5e043a2af066fa8cbfc6e708d58017024dc4345a1f9757b329a249f041b"},
+    {file = "coverage-6.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4433b90fae13f86fafff0b326453dd42fc9a639a0d9e4eec4d366436d1a41b6d"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4f05d88d9a80ad3cac6244d36dd89a3c00abc16371769f1340101d3cb899fc3"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:94e2565443291bd778421856bc975d351738963071e9b8839ca1fc08b42d4bef"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:027018943386e7b942fa832372ebc120155fd970837489896099f5cfa2890f79"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:255758a1e3b61db372ec2736c8e2a1fdfaf563977eedbdf131de003ca5779b7d"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:851cf4ff24062c6aec510a454b2584f6e998cada52d4cb58c5e233d07172e50c"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:12adf310e4aafddc58afdb04d686795f33f4d7a6fa67a7a9d4ce7d6ae24d949f"},
+    {file = "coverage-6.5.0-cp37-cp37m-win32.whl", hash = "sha256:b5604380f3415ba69de87a289a2b56687faa4fe04dbee0754bfcae433489316b"},
+    {file = "coverage-6.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4a8dbc1f0fbb2ae3de73eb0bdbb914180c7abfbf258e90b311dcd4f585d44bd2"},
+    {file = "coverage-6.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d900bb429fdfd7f511f868cedd03a6bbb142f3f9118c09b99ef8dc9bf9643c3c"},
+    {file = "coverage-6.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2198ea6fc548de52adc826f62cb18554caedfb1d26548c1b7c88d8f7faa8f6ba"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c4459b3de97b75e3bd6b7d4b7f0db13f17f504f3d13e2a7c623786289dd670e"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:20c8ac5386253717e5ccc827caad43ed66fea0efe255727b1053a8154d952398"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b07130585d54fe8dff3d97b93b0e20290de974dc8177c320aeaf23459219c0b"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:dbdb91cd8c048c2b09eb17713b0c12a54fbd587d79adcebad543bc0cd9a3410b"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:de3001a203182842a4630e7b8d1a2c7c07ec1b45d3084a83d5d227a3806f530f"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e07f4a4a9b41583d6eabec04f8b68076ab3cd44c20bd29332c6572dda36f372e"},
+    {file = "coverage-6.5.0-cp38-cp38-win32.whl", hash = "sha256:6d4817234349a80dbf03640cec6109cd90cba068330703fa65ddf56b60223a6d"},
+    {file = "coverage-6.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:7ccf362abd726b0410bf8911c31fbf97f09f8f1061f8c1cf03dfc4b6372848f6"},
+    {file = "coverage-6.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:633713d70ad6bfc49b34ead4060531658dc6dfc9b3eb7d8a716d5873377ab745"},
+    {file = "coverage-6.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:95203854f974e07af96358c0b261f1048d8e1083f2de9b1c565e1be4a3a48cfc"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9023e237f4c02ff739581ef35969c3739445fb059b060ca51771e69101efffe"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:265de0fa6778d07de30bcf4d9dc471c3dc4314a23a3c6603d356a3c9abc2dfcf"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f830ed581b45b82451a40faabb89c84e1a998124ee4212d440e9c6cf70083e5"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:7b6be138d61e458e18d8e6ddcddd36dd96215edfe5f1168de0b1b32635839b62"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:42eafe6778551cf006a7c43153af1211c3aaab658d4d66fa5fcc021613d02518"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:723e8130d4ecc8f56e9a611e73b31219595baa3bb252d539206f7bbbab6ffc1f"},
+    {file = "coverage-6.5.0-cp39-cp39-win32.whl", hash = "sha256:d9ecf0829c6a62b9b573c7bb6d4dcd6ba8b6f80be9ba4fc7ed50bf4ac9aecd72"},
+    {file = "coverage-6.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:fc2af30ed0d5ae0b1abdb4ebdce598eafd5b35397d4d75deb341a614d333d987"},
+    {file = "coverage-6.5.0-pp36.pp37.pp38-none-any.whl", hash = "sha256:1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a"},
+    {file = "coverage-6.5.0.tar.gz", hash = "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84"},
+]
+deprecated = [
+    {file = "Deprecated-1.2.13-py2.py3-none-any.whl", hash = "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"},
+    {file = "Deprecated-1.2.13.tar.gz", hash = "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d"},
+]
+distlib = [
+    {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
+    {file = "distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
+]
+filelock = [
+    {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
+    {file = "filelock-3.8.0.tar.gz", hash = "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"},
+]
+idna = [
+    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+jinja2 = [
+    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
+    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+]
+markupsafe = [
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win32.whl", hash = "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6"},
+    {file = "MarkupSafe-2.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win32.whl", hash = "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff"},
+    {file = "MarkupSafe-2.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win32.whl", hash = "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1"},
+    {file = "MarkupSafe-2.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win32.whl", hash = "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c"},
+    {file = "MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247"},
+    {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
+]
+mypy = [
+    {file = "mypy-0.982-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5085e6f442003fa915aeb0a46d4da58128da69325d8213b4b35cc7054090aed5"},
+    {file = "mypy-0.982-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:41fd1cf9bc0e1c19b9af13a6580ccb66c381a5ee2cf63ee5ebab747a4badeba3"},
+    {file = "mypy-0.982-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f793e3dd95e166b66d50e7b63e69e58e88643d80a3dcc3bcd81368e0478b089c"},
+    {file = "mypy-0.982-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86ebe67adf4d021b28c3f547da6aa2cce660b57f0432617af2cca932d4d378a6"},
+    {file = "mypy-0.982-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:175f292f649a3af7082fe36620369ffc4661a71005aa9f8297ea473df5772046"},
+    {file = "mypy-0.982-cp310-cp310-win_amd64.whl", hash = "sha256:8ee8c2472e96beb1045e9081de8e92f295b89ac10c4109afdf3a23ad6e644f3e"},
+    {file = "mypy-0.982-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58f27ebafe726a8e5ccb58d896451dd9a662a511a3188ff6a8a6a919142ecc20"},
+    {file = "mypy-0.982-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6af646bd46f10d53834a8e8983e130e47d8ab2d4b7a97363e35b24e1d588947"},
+    {file = "mypy-0.982-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e7aeaa763c7ab86d5b66ff27f68493d672e44c8099af636d433a7f3fa5596d40"},
+    {file = "mypy-0.982-cp37-cp37m-win_amd64.whl", hash = "sha256:724d36be56444f569c20a629d1d4ee0cb0ad666078d59bb84f8f887952511ca1"},
+    {file = "mypy-0.982-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14d53cdd4cf93765aa747a7399f0961a365bcddf7855d9cef6306fa41de01c24"},
+    {file = "mypy-0.982-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:26ae64555d480ad4b32a267d10cab7aec92ff44de35a7cd95b2b7cb8e64ebe3e"},
+    {file = "mypy-0.982-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6389af3e204975d6658de4fb8ac16f58c14e1bacc6142fee86d1b5b26aa52bda"},
+    {file = "mypy-0.982-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b35ce03a289480d6544aac85fa3674f493f323d80ea7226410ed065cd46f206"},
+    {file = "mypy-0.982-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c6e564f035d25c99fd2b863e13049744d96bd1947e3d3d2f16f5828864506763"},
+    {file = "mypy-0.982-cp38-cp38-win_amd64.whl", hash = "sha256:cebca7fd333f90b61b3ef7f217ff75ce2e287482206ef4a8b18f32b49927b1a2"},
+    {file = "mypy-0.982-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a705a93670c8b74769496280d2fe6cd59961506c64f329bb179970ff1d24f9f8"},
+    {file = "mypy-0.982-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:75838c649290d83a2b83a88288c1eb60fe7a05b36d46cbea9d22efc790002146"},
+    {file = "mypy-0.982-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:91781eff1f3f2607519c8b0e8518aad8498af1419e8442d5d0afb108059881fc"},
+    {file = "mypy-0.982-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaa97b9ddd1dd9901a22a879491dbb951b5dec75c3b90032e2baa7336777363b"},
+    {file = "mypy-0.982-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a692a8e7d07abe5f4b2dd32d731812a0175626a90a223d4b58f10f458747dd8a"},
+    {file = "mypy-0.982-cp39-cp39-win_amd64.whl", hash = "sha256:eb7a068e503be3543c4bd329c994103874fa543c1727ba5288393c21d912d795"},
+    {file = "mypy-0.982-py3-none-any.whl", hash = "sha256:1021c241e8b6e1ca5a47e4d52601274ac078a89845cfde66c6d5f769819ffa1d"},
+    {file = "mypy-0.982.tar.gz", hash = "sha256:85f7a343542dc8b1ed0a888cdd34dca56462654ef23aa673907305b260b3d746"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pycparser = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+pygithub = [
+    {file = "PyGithub-1.56-py3-none-any.whl", hash = "sha256:d15f13d82165306da8a68aefc0f848a6f6432d5febbff13b60a94758ce3ef8b5"},
+    {file = "PyGithub-1.56.tar.gz", hash = "sha256:80c6d85cf0f9418ffeb840fd105840af694c4f17e102970badbaf678251f2a01"},
+]
+pyjwt = [
+    {file = "PyJWT-2.5.0-py3-none-any.whl", hash = "sha256:8d82e7087868e94dd8d7d418e5088ce64f7daab4b36db654cbaedb46f9d1ca80"},
+    {file = "PyJWT-2.5.0.tar.gz", hash = "sha256:e77ab89480905d86998442ac5788f35333fa85f65047a534adc38edf3c88fc3b"},
+]
+pynacl = [
+    {file = "PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93"},
+    {file = "PyNaCl-1.5.0.tar.gz", hash = "sha256:8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pytest = [
+    {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
+    {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
+]
+pytest-cov = [
+    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
+    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.10.0.tar.gz", hash = "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"},
+    {file = "pytest_mock-3.10.0-py3-none-any.whl", hash = "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b"},
+]
+pytest-mypy = [
+    {file = "pytest-mypy-0.10.0.tar.gz", hash = "sha256:e74d632685f15a39c31c551a9d8cec4619e24bd396245a6335c5db0ec6d17b6f"},
+    {file = "pytest_mypy-0.10.0-py3-none-any.whl", hash = "sha256:83843dce75a7ce055efb264ff40dad2ecf7abd4e7bd5e5eda015261d11616abb"},
+]
+requests = [
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+]
+responses = [
+    {file = "responses-0.22.0-py3-none-any.whl", hash = "sha256:dcf294d204d14c436fddcc74caefdbc5764795a40ff4e6a7740ed8ddbf3294be"},
+    {file = "responses-0.22.0.tar.gz", hash = "sha256:396acb2a13d25297789a5866b4881cf4e46ffd49cc26c43ab1117f40b973102e"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+types-atomicwrites = [
+    {file = "types-atomicwrites-1.4.5.1.tar.gz", hash = "sha256:9e9f0923ebf93524b28bcece5a23ac8c3820f39b060df29f671936d2e4bc04bc"},
+    {file = "types_atomicwrites-1.4.5.1-py3-none-any.whl", hash = "sha256:2f1febbdc78b55453b189fa5b136dce34bab7d1d82319163d470e404aab55c83"},
+]
+types-requests = [
+    {file = "types-requests-2.28.11.2.tar.gz", hash = "sha256:fdcd7bd148139fb8eef72cf4a41ac7273872cad9e6ada14b11ff5dfdeee60ed3"},
+    {file = "types_requests-2.28.11.2-py3-none-any.whl", hash = "sha256:14941f8023a80b16441b3b46caffcbfce5265fd14555844d6029697824b5a2ef"},
+]
+types-toml = [
+    {file = "types-toml-0.10.8.tar.gz", hash = "sha256:b7e7ea572308b1030dc86c3ba825c5210814c2825612ec679eb7814f8dd9295a"},
+    {file = "types_toml-0.10.8-py3-none-any.whl", hash = "sha256:8300fd093e5829eb9c1fba69cee38130347d4b74ddf32d0a7df650ae55c2b599"},
+]
+types-urllib3 = [
+    {file = "types-urllib3-1.26.25.1.tar.gz", hash = "sha256:a948584944b2412c9a74b9cf64f6c48caf8652cb88b38361316f6d15d8a184cd"},
+    {file = "types_urllib3-1.26.25.1-py3-none-any.whl", hash = "sha256:f6422596cc9ee5fdf68f9d547f541096a20c2dcfd587e37c804c9ea720bf5cb2"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
+    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
+]
+wrapt = [
+    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
+    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
+    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
+    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
+    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
+    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
+    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
+    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
+    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
+    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,39 +10,24 @@ ghpypi = "ghpypi:main"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-PyGithub = "^1.55"
-distlib = "^0.3.5"
+PyGithub = "^1.56"
+distlib = "^0.3.6"
 Jinja2 = "^3.1.2"
 packaging = "^21.3"
 atomicwrites = "^1.4.1"
 requests = "^2.28.1"
 
-[tool.poetry.dev-dependencies]
-pytest = "^7.1.2"
-pytest-mock = "^3.8.2"
-pytest-mypy = "^0.9.1"
-pytest-flake8 = "^1.1.1"
-pytest-isort = "^3.0.0"
-pytest-cov = "^3.0.0"
-flake8-annotations = "^2.9.1"
-flake8-bandit = "^3.0.0"
-flake8-broken-line = "^0.5.0"
-flake8-builtins = "^1.5.3"
-flake8-bugbear = "^22.7.1"
-flake8-commas = "^2.1.0"
-flake8-comprehensions = "^3.10.0"
-flake8-no-implicit-concat = "^0.3.3"
-flake8-pylint = "^0.1.3"
-flake8-quotes = "^3.3.1"
-flake8-simplify = "^0.19.2"
-pep8-naming = "^0.13.0"
-types-requests = "^2.28.8"
-types-atomicwrites = "^1.4.5"
-responses = "^0.21.0"
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.1.3"
+pytest-cov = "^4.0.0"
+pytest-mock = "^3.10.0"
+pytest-mypy = "^0.10.0"
+
+# mypy dependencies
+types-requests = "^2.28.11.2"
+types-atomicwrites = "^1.4.5.1"
+responses = "^0.22.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.pytest.ini_options]
-#addopts = "--flake8 --mypy --isort --cov=src --cov-report=term --cov-report=html --log-level=ERROR -p no:warnings"

--- a/src/ghpypi/__init__.py
+++ b/src/ghpypi/__init__.py
@@ -39,7 +39,8 @@ def parse_arguments(arguments: List[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--title",
-        help="site title (for web interface)", default="My Private PyPI",
+        help="site title (for web interface)",
+        default="My Private PyPI",
     )
     parser.add_argument(
         "-v",

--- a/src/ghpypi/ghpypi.py
+++ b/src/ghpypi/ghpypi.py
@@ -7,8 +7,18 @@ import os.path
 import re
 import sys
 from datetime import datetime
-from typing import (Any, Dict, Iterator, List, NamedTuple, Optional, Set,
-                    Tuple, Union, cast)
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 import distlib.wheel  # type: ignore
 import github
@@ -102,12 +112,15 @@ class Package(NamedTuple):
         return cast("Package", self).sort_key < cast("Package", other).sort_key
 
     @property
-    def sort_key(self: "Package") -> Tuple[str, Union[packaging.version.LegacyVersion, packaging.version.Version], str]:
+    def sort_key(
+        self: "Package",
+    ) -> Tuple[
+        str, Union[packaging.version.LegacyVersion, packaging.version.Version], str
+    ]:
         """Sort key for a file name."""
         return (
             self.name,
             self.version,
-
             # This looks ridiculous, but it's so that like extensions sort
             # together when the name and version are the same (otherwise it
             # depends on how the file name is normalized, which means sometimes
@@ -125,11 +138,13 @@ def get_package_json(files: List[Package]) -> Dict[str, Any]:
 
     latest = files[-1]
     for f in files:
-        by_version[str(f.version)].append({
-            "filename": f.filename,
-            "url": f.url,
-            "digests": {"sha256": f.sha256},
-        })
+        by_version[str(f.version)].append(
+            {
+                "filename": f.filename,
+                "url": f.url,
+                "digests": {"sha256": f.sha256},
+            }
+        )
 
     return {
         "info": {
@@ -160,11 +175,15 @@ def build(packages: Dict[str, Set[Package]], output: str, title: str) -> None:
         # /simple/{package}/index.html
         simple_package_dir = os.path.join(simple, package_name)
         os.makedirs(simple_package_dir, exist_ok=True)
-        with atomic_write(os.path.join(simple_package_dir, "index.html"), overwrite=True) as f:
-            f.write(jinja_env.get_template("package.html").render(
-                package_name=package_name,
-                files=sorted_files,
-            ))
+        with atomic_write(
+            os.path.join(simple_package_dir, "index.html"), overwrite=True
+        ) as f:
+            f.write(
+                jinja_env.get_template("package.html").render(
+                    package_name=package_name,
+                    files=sorted_files,
+                )
+            )
 
         # /pypi/{package}/json
         pypi_package_dir = os.path.join(pypi, package_name)
@@ -175,25 +194,32 @@ def build(packages: Dict[str, Set[Package]], output: str, title: str) -> None:
     # /simple/index.html
     os.makedirs(simple, exist_ok=True)
     with atomic_write(os.path.join(simple, "index.html"), overwrite=True) as f:
-        f.write(jinja_env.get_template("simple.html").render(
-            package_names=sorted_packages,
-        ))
+        f.write(
+            jinja_env.get_template("simple.html").render(
+                package_names=sorted_packages,
+            )
+        )
 
     # /index.html
     with atomic_write(os.path.join(output, "index.html"), overwrite=True) as f:
-        f.write(jinja_env.get_template("index.html").render(
-            packages=sorted(
-                (
-                    package,
-                    sorted_versions[-1].version,
-                )
-                for package, sorted_versions in sorted_packages.items()
-            ),
-        ))
+        f.write(
+            jinja_env.get_template("index.html").render(
+                packages=sorted(
+                    (
+                        package,
+                        sorted_versions[-1].version,
+                    )
+                    for package, sorted_versions in sorted_packages.items()
+                ),
+            )
+        )
 
 
 def create_package(artifact: Artifact) -> Package:
-    if not re.match(r"[a-zA-Z\d_\-\.\+]+$", artifact.filename) or ".." in artifact.filename:
+    if (
+        not re.match(r"[a-zA-Z\d_\-\.\+]+$", artifact.filename)
+        or ".." in artifact.filename
+    ):
         raise ValueError(f"unsafe package name: {artifact.filename}")
 
     # set values that the user did not provide
@@ -271,7 +297,9 @@ def get_github_token(token: Optional[str], token_stdin: bool) -> str:
 
 
 def get_artifacts(token: str, repository: Repository) -> Iterator[Artifact]:
-    logger.info("fetching release artifacts for %s/%s", repository.owner, repository.name)
+    logger.info(
+        "fetching release artifacts for %s/%s", repository.owner, repository.name
+    )
 
     gh = github.Github(token)
     gh_repo = gh.get_repo(f"{repository.owner}/{repository.name}")
@@ -297,7 +325,12 @@ def create_artifacts(assets: list[dict]) -> Iterator[Artifact]:
         url = asset["browser_download_url"]
 
         # we only want wheels and tar.gz and maybe pre-existing checksums
-        if not (name.endswith(".whl") or name.endswith(".gz") or name.endswith(".bz2") or name == "sha256sum.txt"):
+        if not (
+            name.endswith(".whl")
+            or name.endswith(".gz")
+            or name.endswith(".bz2")
+            or name == "sha256sum.txt"
+        ):
             continue
 
         if name == "sha256sum.txt":
@@ -308,16 +341,27 @@ def create_artifacts(assets: list[dict]) -> Iterator[Artifact]:
             response.encoding = "ascii"
 
             # split lines then split each line
-            sha256sums = {x[1]: x[0] for x in [line.strip().split() for line in response.text.split("\n") if len(line.strip())]}
+            sha256sums = {
+                x[1]: x[0]
+                for x in [
+                    line.strip().split()
+                    for line in response.text.split("\n")
+                    if len(line.strip())
+                ]
+            }
 
         else:
-            results.append({
-                "filename": name,
-                "url": url,
-                "sha256": None,
-                "uploaded_at": datetime.fromisoformat(asset["updated_at"].rstrip("Z")),
-                "uploaded_by": asset["uploader"]["login"],
-            })
+            results.append(
+                {
+                    "filename": name,
+                    "url": url,
+                    "sha256": None,
+                    "uploaded_at": datetime.fromisoformat(
+                        asset["updated_at"].rstrip("Z")
+                    ),
+                    "uploaded_by": asset["uploader"]["login"],
+                }
+            )
 
     for result in results:
         if result["filename"] in sha256sums:
@@ -340,7 +384,13 @@ def create_artifacts(assets: list[dict]) -> Iterator[Artifact]:
         yield Artifact(**result)
 
 
-def run(repositories: str, output: str, token: str, token_stdin: bool, title: Optional[str] = None) -> None:
+def run(
+    repositories: str,
+    output: str,
+    token: str,
+    token_stdin: bool,
+    title: Optional[str] = None,
+) -> None:
     packages = {}
     token = get_github_token(token, token_stdin)
     for repository in load_repositories(repositories):

--- a/src/ghpypi/ghpypi.py
+++ b/src/ghpypi/ghpypi.py
@@ -115,7 +115,9 @@ class Package(NamedTuple):
     def sort_key(
         self: "Package",
     ) -> Tuple[
-        str, Union[packaging.version.LegacyVersion, packaging.version.Version], str
+        str,
+        Union[packaging.version.LegacyVersion, packaging.version.Version],
+        str,
     ]:
         """Sort key for a file name."""
         return (
@@ -143,7 +145,7 @@ def get_package_json(files: List[Package]) -> Dict[str, Any]:
                 "filename": f.filename,
                 "url": f.url,
                 "digests": {"sha256": f.sha256},
-            }
+            },
         )
 
     return {
@@ -176,13 +178,14 @@ def build(packages: Dict[str, Set[Package]], output: str, title: str) -> None:
         simple_package_dir = os.path.join(simple, package_name)
         os.makedirs(simple_package_dir, exist_ok=True)
         with atomic_write(
-            os.path.join(simple_package_dir, "index.html"), overwrite=True
+            os.path.join(simple_package_dir, "index.html"),
+            overwrite=True,
         ) as f:
             f.write(
                 jinja_env.get_template("package.html").render(
                     package_name=package_name,
                     files=sorted_files,
-                )
+                ),
             )
 
         # /pypi/{package}/json
@@ -197,7 +200,7 @@ def build(packages: Dict[str, Set[Package]], output: str, title: str) -> None:
         f.write(
             jinja_env.get_template("simple.html").render(
                 package_names=sorted_packages,
-            )
+            ),
         )
 
     # /index.html
@@ -211,7 +214,7 @@ def build(packages: Dict[str, Set[Package]], output: str, title: str) -> None:
                     )
                     for package, sorted_versions in sorted_packages.items()
                 ),
-            )
+            ),
         )
 
 
@@ -298,7 +301,9 @@ def get_github_token(token: Optional[str], token_stdin: bool) -> str:
 
 def get_artifacts(token: str, repository: Repository) -> Iterator[Artifact]:
     logger.info(
-        "fetching release artifacts for %s/%s", repository.owner, repository.name
+        "fetching release artifacts for %s/%s",
+        repository.owner,
+        repository.name,
     )
 
     gh = github.Github(token)
@@ -357,10 +362,10 @@ def create_artifacts(assets: list[dict]) -> Iterator[Artifact]:
                     "url": url,
                     "sha256": None,
                     "uploaded_at": datetime.fromisoformat(
-                        asset["updated_at"].rstrip("Z")
+                        asset["updated_at"].rstrip("Z"),
                     ),
                     "uploaded_by": asset["uploader"]["login"],
-                }
+                },
             )
 
     for result in results:

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -3,21 +3,32 @@ import pytest
 import ghpypi
 
 
-@pytest.mark.parametrize("arguments", (
-    [],
-    ["--token", "asdf", "--token-stdin"],
-    ["--token-stdin"],
-    ["--token", "asdf"],
-    ["--token", "asdf", "--output", "/path/to/nowhere"],
-    ["--token", "asdf", "--repositories", "/path/to/nowhere.txt"],
-))
+@pytest.mark.parametrize(
+    "arguments",
+    (
+        [],
+        ["--token", "asdf", "--token-stdin"],
+        ["--token-stdin"],
+        ["--token", "asdf"],
+        ["--token", "asdf", "--output", "/path/to/nowhere"],
+        ["--token", "asdf", "--repositories", "/path/to/nowhere.txt"],
+    ),
+)
 def test_parse_arguments(arguments):
     with pytest.raises(SystemExit):
         ghpypi.parse_arguments(arguments)
 
 
 def test_valid_values():
-    x = ghpypi.parse_arguments(["--token-stdin", "--output", "/path/to/output", "--repositories", "/path/to/repos.txt"])
+    x = ghpypi.parse_arguments(
+        [
+            "--token-stdin",
+            "--output",
+            "/path/to/output",
+            "--repositories",
+            "/path/to/repos.txt",
+        ]
+    )
     assert not x.verbose
     assert x.title == "My Private PyPI"
     assert x.output == "/path/to/output"
@@ -25,7 +36,16 @@ def test_valid_values():
     assert x.token_stdin
     assert x.token is None
 
-    x = ghpypi.parse_arguments(["--token", "asdf", "--output", "/path/to/output", "--repositories", "/path/to/repos.txt"])
+    x = ghpypi.parse_arguments(
+        [
+            "--token",
+            "asdf",
+            "--output",
+            "/path/to/output",
+            "--repositories",
+            "/path/to/repos.txt",
+        ]
+    )
     assert not x.verbose
     assert x.title == "My Private PyPI"
     assert x.output == "/path/to/output"

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -27,7 +27,7 @@ def test_valid_values():
             "/path/to/output",
             "--repositories",
             "/path/to/repos.txt",
-        ]
+        ],
     )
     assert not x.verbose
     assert x.title == "My Private PyPI"
@@ -44,7 +44,7 @@ def test_valid_values():
             "/path/to/output",
             "--repositories",
             "/path/to/repos.txt",
-        ]
+        ],
     )
     assert not x.verbose
     assert x.title == "My Private PyPI"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,67 +14,83 @@ from ghpypi import ghpypi
 from ghpypi.ghpypi import Artifact, Package
 
 
-@pytest.mark.parametrize(("package_name", "version"), (
-    ("completely invalid package", "0.0.0"),
-    ("ghpypi", "0.0.0"),
-    ("pytest", pytest.__version__),
-))
+@pytest.mark.parametrize(
+    ("package_name", "version"),
+    (
+        ("completely invalid package", "0.0.0"),
+        ("ghpypi", "0.0.0"),
+        ("pytest", pytest.__version__),
+    ),
+)
 def test_get_version(package_name: str, version: str):
     assert ghpypi.get_version(package_name) == version
 
 
-@pytest.mark.parametrize(("file_name", "cleaned"), (
-    ("foo.bar", "foo"),
-    ("mypackage.whl", "mypackage"),
-    ("mypackage.whatever.whl", "mypackage.whatever"),
-    ("mypackage.tar.gz", "mypackage"),
-    ("mypackage.tar.bz2", "mypackage"),
-    ("mypackage.tar.xz", "mypackage"),
-    ("mypackage.gz", "mypackage"),
-    ("mypackage.bz2", "mypackage"),
-    ("mypackage.xz", "mypackage"),
-    ("mypackage.asdf", "mypackage"),
-))
+@pytest.mark.parametrize(
+    ("file_name", "cleaned"),
+    (
+        ("foo.bar", "foo"),
+        ("mypackage.whl", "mypackage"),
+        ("mypackage.whatever.whl", "mypackage.whatever"),
+        ("mypackage.tar.gz", "mypackage"),
+        ("mypackage.tar.bz2", "mypackage"),
+        ("mypackage.tar.xz", "mypackage"),
+        ("mypackage.gz", "mypackage"),
+        ("mypackage.bz2", "mypackage"),
+        ("mypackage.xz", "mypackage"),
+        ("mypackage.asdf", "mypackage"),
+    ),
+)
 def test_remove_extension(file_name: str, cleaned: str):
     assert ghpypi.remove_package_extension(file_name) == cleaned
 
 
-@pytest.mark.parametrize(("file_name", "name", "version"), (
-    # wheels
-    ("dumb_init-1.2.0-py2.py3-none-manylinux1_x86_64.whl", "dumb_init", "1.2.0"),
-    ("ocflib-2016.12.10.1.48-py2.py3-none-any.whl", "ocflib", "2016.12.10.1.48"),
-    ("aspy.yaml-0.2.2-py2.py3-none-any.whl", "aspy.yaml", "0.2.2"),
+@pytest.mark.parametrize(
+    ("file_name", "name", "version"),
     (
-        "numpy-1.11.1rc1-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl",  # noqa
-        "numpy",
-        "1.11.1rc1",
+        # wheels
+        ("dumb_init-1.2.0-py2.py3-none-manylinux1_x86_64.whl", "dumb_init", "1.2.0"),
+        ("ocflib-2016.12.10.1.48-py2.py3-none-any.whl", "ocflib", "2016.12.10.1.48"),
+        ("aspy.yaml-0.2.2-py2.py3-none-any.whl", "aspy.yaml", "0.2.2"),
+        (
+            "numpy-1.11.1rc1-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl",  # noqa
+            "numpy",
+            "1.11.1rc1",
+        ),
+        # other stuff
+        ("aspy.yaml.zip", "aspy.yaml", None),
+        ("ocflib-3-4.tar.gz", "ocflib-3-4", None),
+        ("aspy.yaml-0.2.1.tar.gz", "aspy.yaml", "0.2.1"),
+        ("numpy-1.11.0rc1.tar.gz", "numpy", "1.11.0rc1"),
+        ("pandas-0.2beta.tar.gz", "pandas", "0.2beta"),
+        ("scikit-learn-0.15.1.tar.gz", "scikit-learn", "0.15.1"),
+        ("ocflib-2015.11.23.20.2.tar.gz", "ocflib", "2015.11.23.20.2"),
+        ("mesos.cli-0.1.3-py2.7.egg", "mesos.cli", "0.1.3-py2.7"),
+        # inspired by pypiserver"s tests
+        ("flup-123-1.0.3.dev-20110405.tar.gz", "flup-123", "1.0.3.dev-20110405"),
+        (
+            "package-123-1.3.7+build.11.e0f985a.zip",
+            "package-123",
+            "1.3.7+build.11.e0f985a",
+        ),
     ),
-
-    # other stuff
-    ("aspy.yaml.zip", "aspy.yaml", None),
-    ("ocflib-3-4.tar.gz", "ocflib-3-4", None),
-    ("aspy.yaml-0.2.1.tar.gz", "aspy.yaml", "0.2.1"),
-    ("numpy-1.11.0rc1.tar.gz", "numpy", "1.11.0rc1"),
-    ("pandas-0.2beta.tar.gz", "pandas", "0.2beta"),
-    ("scikit-learn-0.15.1.tar.gz", "scikit-learn", "0.15.1"),
-    ("ocflib-2015.11.23.20.2.tar.gz", "ocflib", "2015.11.23.20.2"),
-    ("mesos.cli-0.1.3-py2.7.egg", "mesos.cli", "0.1.3-py2.7"),
-
-    # inspired by pypiserver"s tests
-    ("flup-123-1.0.3.dev-20110405.tar.gz", "flup-123", "1.0.3.dev-20110405"),
-    ("package-123-1.3.7+build.11.e0f985a.zip", "package-123", "1.3.7+build.11.e0f985a"),
-))
+)
 def test_guess_name_version_from_filename(file_name: str, name: str, version: str):
     assert ghpypi.guess_name_version_from_filename(file_name) == (name, version)
 
 
-@pytest.mark.parametrize(("file_name", "name", "version"), (
-    ("dumb-init-0.1.0.linux-x86_64.tar.gz", "dumb-init", "0.1.0"),
-    ("greenlet-0.3.4-py3.1-win-amd64.egg", "greenlet", "0.3.4"),
-    ("numpy-1.7.0.win32-py3.1.exe", "numpy", "1.7.0"),
-    ("surf.sesame2-0.2.1_r291-py2.5.egg", "surf.sesame2", "0.2.1_r291"),
-))
-def test_guess_name_version_from_filename_only_name(file_name: str, name: str, version: str):
+@pytest.mark.parametrize(
+    ("file_name", "name", "version"),
+    (
+        ("dumb-init-0.1.0.linux-x86_64.tar.gz", "dumb-init", "0.1.0"),
+        ("greenlet-0.3.4-py3.1-win-amd64.egg", "greenlet", "0.3.4"),
+        ("numpy-1.7.0.win32-py3.1.exe", "numpy", "1.7.0"),
+        ("surf.sesame2-0.2.1_r291-py2.5.egg", "surf.sesame2", "0.2.1_r291"),
+    ),
+)
+def test_guess_name_version_from_filename_only_name(
+    file_name: str, name: str, version: str
+):
     """Broken version check tests.
     The real important thing is to be able to parse the name, but it's nice if
     we can parse the versions too. Unfortunately, we can't yet for these cases.
@@ -86,13 +102,16 @@ def test_guess_name_version_from_filename_only_name(file_name: str, name: str, v
     assert parsed_version != version
 
 
-@pytest.mark.parametrize("file_name", (
-    "",
-    "lol",
-    "lol-sup",
-    "-20160920.193125.zip",
-    "playlyfe-0.1.1-2.7.6-none-any.whl",  # 2.7.6 is not a valid python tag
-))
+@pytest.mark.parametrize(
+    "file_name",
+    (
+        "",
+        "lol",
+        "lol-sup",
+        "-20160920.193125.zip",
+        "playlyfe-0.1.1-2.7.6-none-any.whl",  # 2.7.6 is not a valid python tag
+    ),
+)
 def test_guess_name_version_from_filename_invalid(file_name: str):
     with pytest.raises(ValueError):
         ghpypi.guess_name_version_from_filename(file_name)
@@ -100,12 +119,14 @@ def test_guess_name_version_from_filename_invalid(file_name: str):
 
 def test_load_repositories(tmp_path: PosixPath):
     tmp_data = tmp_path / "repos.txt"
-    tmp_data.write_text("""
+    tmp_data.write_text(
+        """
 
         # this is a comment
         foo/bar
         baz/bat
-    """)
+    """
+    )
 
     tmp_data_path = str(tmp_data)
     repos = ghpypi.load_repositories(tmp_data_path)
@@ -115,14 +136,17 @@ def test_load_repositories(tmp_path: PosixPath):
     assert result[1] == ghpypi.Repository("baz", "bat")
 
 
-@pytest.mark.parametrize("data", (
-    "some invalid data",
-    "; this is invalid",
-    "foo/bar/asdf",
-    "baz/",
-    "bat",
-    "/battery",
-))
+@pytest.mark.parametrize(
+    "data",
+    (
+        "some invalid data",
+        "; this is invalid",
+        "foo/bar/asdf",
+        "baz/",
+        "bat",
+        "/battery",
+    ),
+)
 # using the "tmp_path" argument MAGICALLY gives us a temporary directory to put things *eye roll*
 def test_load_bad_repositories(tmp_path: PosixPath, data: str):
     tmp_data = tmp_path / "repos.txt"
@@ -138,7 +162,10 @@ def test_github_tokens(mocker: MockerFixture):
     original_environ = os.environ.get
 
     # make calls to get GITHUB_TOKEN return None
-    mocker.patch("os.environ.get", lambda key: None if key == "GITHUB_TOKEN" else original_environ(key))
+    mocker.patch(
+        "os.environ.get",
+        lambda key: None if key == "GITHUB_TOKEN" else original_environ(key),
+    )
 
     # token provided, do not read from stdin
     assert ghpypi.get_github_token("foo", False) == "foo"
@@ -169,16 +196,25 @@ def test_github_tokens(mocker: MockerFixture):
         ghpypi.get_github_token(None, True)
 
     # token in the environment
-    mocker.patch("os.environ.get", lambda key: "foobarbaz" if key == "GITHUB_TOKEN" else original_environ(key))
+    mocker.patch(
+        "os.environ.get",
+        lambda key: "foobarbaz" if key == "GITHUB_TOKEN" else original_environ(key),
+    )
     assert ghpypi.get_github_token(None, False) == "foobarbaz"
 
     # token in environment but empty
-    mocker.patch("os.environ.get", lambda key: "" if key == "GITHUB_TOKEN" else original_environ(key))
+    mocker.patch(
+        "os.environ.get",
+        lambda key: "" if key == "GITHUB_TOKEN" else original_environ(key),
+    )
     with pytest.raises(ValueError):
         ghpypi.get_github_token(None, False)
 
     # token in environment but empty spaces
-    mocker.patch("os.environ.get", lambda key: "    " if key == "GITHUB_TOKEN" else original_environ(key))
+    mocker.patch(
+        "os.environ.get",
+        lambda key: "    " if key == "GITHUB_TOKEN" else original_environ(key),
+    )
     with pytest.raises(ValueError):
         ghpypi.get_github_token(None, False)
 
@@ -195,9 +231,12 @@ def test_get_artifacts(mocker: MockerFixture):
     # make it return a second mock that imitates a "github.Repository.Repository"
     # object implements the "get_releases" function and makes it return an
     # empty list. that is all.
-    mock_get_repo = mocker.Mock(spec=github.Repository.Repository, **{
-        "get_releases.return_value": [],
-    })
+    mock_get_repo = mocker.Mock(
+        spec=github.Repository.Repository,
+        **{
+            "get_releases.return_value": [],
+        }
+    )
     mocker.patch("github.MainClass.Github.get_repo", return_value=mock_get_repo)
     releases = list(ghpypi.get_artifacts(token, repository))
     assert len(releases) == 0
@@ -207,13 +246,19 @@ def test_get_artifacts(mocker: MockerFixture):
     # the "github.Repository.Repository" class, we need it to return another
     # mock that implements "github.GitRelease.GitRelease" and then we want to
     # mock the "raw_data" function and have it return an empty dict.
-    mock_get_repo = mocker.Mock(spec=github.Repository.Repository, **{
-        "get_releases.return_value": [
-            mocker.Mock(spec=github.GitRelease.GitRelease, **{
-                "raw_data": {},
-            }),
-        ],
-    })
+    mock_get_repo = mocker.Mock(
+        spec=github.Repository.Repository,
+        **{
+            "get_releases.return_value": [
+                mocker.Mock(
+                    spec=github.GitRelease.GitRelease,
+                    **{
+                        "raw_data": {},
+                    }
+                ),
+            ],
+        }
+    )
     mocker.patch("github.MainClass.Github.get_repo", return_value=mock_get_repo)
     releases = list(ghpypi.get_artifacts(token, repository))
     assert len(releases) == 0
@@ -221,13 +266,19 @@ def test_get_artifacts(mocker: MockerFixture):
     # test releases returning something with no assets.
     # this is exactly like the last example, except that we are putting things
     # into the dict that is being returned when "raw_data" is called.
-    mock_get_repo = mocker.Mock(spec=github.Repository.Repository, **{
-        "get_releases.return_value": [
-            mocker.Mock(spec=github.GitRelease.GitRelease, **{
-                "raw_data": {"assets": []},
-            }),
-        ],
-    })
+    mock_get_repo = mocker.Mock(
+        spec=github.Repository.Repository,
+        **{
+            "get_releases.return_value": [
+                mocker.Mock(
+                    spec=github.GitRelease.GitRelease,
+                    **{
+                        "raw_data": {"assets": []},
+                    }
+                ),
+            ],
+        }
+    )
     mocker.patch("github.MainClass.Github.get_repo", return_value=mock_get_repo)
     releases = list(ghpypi.get_artifacts(token, repository))
     assert len(releases) == 0
@@ -237,225 +288,233 @@ def test_create_packages_empty():
     assert not ghpypi.create_packages([])
 
 
-@pytest.mark.parametrize(("artifacts", "packages"), (
+@pytest.mark.parametrize(
+    ("artifacts", "packages"),
     (
-        [
-            Artifact(
-                filename="ghpypi-1.0.1-py3-none-any.whl",
-                url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/ghpypi-1.0.1-py3-none-any.whl",
-                sha256="ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c",
-                uploaded_at=datetime(2021, 12, 25, 6, 22, 19),
-                uploaded_by="github-actions[bot]",
-            ),
-            Artifact(
-                filename="ghpypi-1.0.1.tar.gz",
-                url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/ghpypi-1.0.1.tar.gz",
-                sha256="0bca915a7d7129b4d5a21e5381fee0678016708139029c0c5ccadf71c0cf5265",
-                uploaded_at=datetime(2021, 12, 25, 6, 22, 19),
-                uploaded_by="github-actions[bot]",
-            ),
-            Artifact(
-                filename="ghpypi-1.0.0-py3-none-any.whl",
-                url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.0/ghpypi-1.0.0-py3-none-any.whl",
-                sha256="8db833603bd5f71a7ae2d94364edcc996dd851f42da0069040cab954be53d48d",
-                uploaded_at=datetime(2021, 12, 25, 6, 16, 8),
-                uploaded_by="github-actions[bot]",
-            ),
-            Artifact(
-                filename="ghpypi-1.0.0.tar.gz",
-                url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.0/ghpypi-1.0.0.tar.gz",
-                sha256="fa6dfbe92d7b150b788da980d53f07e6e84c4079118783d5905a72cc9b636ba3",
-                uploaded_at=datetime(2021, 12, 25, 6, 16, 9),
-                uploaded_by="github-actions[bot]",
-            ),
-            # these will be ignored because they're invalid
-            Artifact(
-                filename="",
-                url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-                sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-                uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-                uploaded_by="github-actions[bot]",
-            ),
-            Artifact(
-                filename="lol",
-                url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-                sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-                uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-                uploaded_by="github-actions[bot]",
-            ),
-            Artifact(
-                filename="lol-sup",
-                url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-                sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-                uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-                uploaded_by="github-actions[bot]",
-            ),
-            Artifact(
-                filename="-20160920.193125.zip",
-                url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-                sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-                uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-                uploaded_by="github-actions[bot]",
-            ),
-            Artifact(
-                filename=".",
-                url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-                sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-                uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-                uploaded_by="github-actions[bot]",
-            ),
-            Artifact(
-                filename="..",
-                url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-                sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-                uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-                uploaded_by="github-actions[bot]",
-            ),
-            Artifact(
-                filename="/blah-2.tar.gz",
-                url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-                sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-                uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-                uploaded_by="github-actions[bot]",
-            ),
-            Artifact(
-                filename="lol-2.tar.gz/../",
-                url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-                sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-                uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-                uploaded_by="github-actions[bot]",
-            ),
-        ],
-        {
-            "ghpypi": {
-                Package(
+        (
+            [
+                Artifact(
                     filename="ghpypi-1.0.1-py3-none-any.whl",
                     url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/ghpypi-1.0.1-py3-none-any.whl",
                     sha256="ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c",
                     uploaded_at=datetime(2021, 12, 25, 6, 22, 19),
                     uploaded_by="github-actions[bot]",
-                    name="ghpypi",
-                    version=packaging.version.Version("1.0.1"),
                 ),
-                Package(
+                Artifact(
                     filename="ghpypi-1.0.1.tar.gz",
                     url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/ghpypi-1.0.1.tar.gz",
                     sha256="0bca915a7d7129b4d5a21e5381fee0678016708139029c0c5ccadf71c0cf5265",
                     uploaded_at=datetime(2021, 12, 25, 6, 22, 19),
                     uploaded_by="github-actions[bot]",
-                    name="ghpypi",
-                    version=packaging.version.Version("1.0.1"),
                 ),
-                Package(
+                Artifact(
                     filename="ghpypi-1.0.0-py3-none-any.whl",
                     url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.0/ghpypi-1.0.0-py3-none-any.whl",
                     sha256="8db833603bd5f71a7ae2d94364edcc996dd851f42da0069040cab954be53d48d",
                     uploaded_at=datetime(2021, 12, 25, 6, 16, 8),
                     uploaded_by="github-actions[bot]",
-                    name="ghpypi",
-                    version=packaging.version.Version("1.0.0"),
                 ),
-                Package(
+                Artifact(
                     filename="ghpypi-1.0.0.tar.gz",
                     url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.0/ghpypi-1.0.0.tar.gz",
                     sha256="fa6dfbe92d7b150b788da980d53f07e6e84c4079118783d5905a72cc9b636ba3",
                     uploaded_at=datetime(2021, 12, 25, 6, 16, 9),
                     uploaded_by="github-actions[bot]",
-                    name="ghpypi",
-                    version=packaging.version.Version("1.0.0"),
                 ),
+                # these will be ignored because they're invalid
+                Artifact(
+                    filename="",
+                    url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+                    sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                    uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+                    uploaded_by="github-actions[bot]",
+                ),
+                Artifact(
+                    filename="lol",
+                    url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+                    sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                    uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+                    uploaded_by="github-actions[bot]",
+                ),
+                Artifact(
+                    filename="lol-sup",
+                    url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+                    sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                    uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+                    uploaded_by="github-actions[bot]",
+                ),
+                Artifact(
+                    filename="-20160920.193125.zip",
+                    url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+                    sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                    uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+                    uploaded_by="github-actions[bot]",
+                ),
+                Artifact(
+                    filename=".",
+                    url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+                    sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                    uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+                    uploaded_by="github-actions[bot]",
+                ),
+                Artifact(
+                    filename="..",
+                    url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+                    sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                    uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+                    uploaded_by="github-actions[bot]",
+                ),
+                Artifact(
+                    filename="/blah-2.tar.gz",
+                    url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+                    sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                    uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+                    uploaded_by="github-actions[bot]",
+                ),
+                Artifact(
+                    filename="lol-2.tar.gz/../",
+                    url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+                    sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                    uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+                    uploaded_by="github-actions[bot]",
+                ),
+            ],
+            {
+                "ghpypi": {
+                    Package(
+                        filename="ghpypi-1.0.1-py3-none-any.whl",
+                        url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/ghpypi-1.0.1-py3-none-any.whl",
+                        sha256="ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c",
+                        uploaded_at=datetime(2021, 12, 25, 6, 22, 19),
+                        uploaded_by="github-actions[bot]",
+                        name="ghpypi",
+                        version=packaging.version.Version("1.0.1"),
+                    ),
+                    Package(
+                        filename="ghpypi-1.0.1.tar.gz",
+                        url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/ghpypi-1.0.1.tar.gz",
+                        sha256="0bca915a7d7129b4d5a21e5381fee0678016708139029c0c5ccadf71c0cf5265",
+                        uploaded_at=datetime(2021, 12, 25, 6, 22, 19),
+                        uploaded_by="github-actions[bot]",
+                        name="ghpypi",
+                        version=packaging.version.Version("1.0.1"),
+                    ),
+                    Package(
+                        filename="ghpypi-1.0.0-py3-none-any.whl",
+                        url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.0/ghpypi-1.0.0-py3-none-any.whl",
+                        sha256="8db833603bd5f71a7ae2d94364edcc996dd851f42da0069040cab954be53d48d",
+                        uploaded_at=datetime(2021, 12, 25, 6, 16, 8),
+                        uploaded_by="github-actions[bot]",
+                        name="ghpypi",
+                        version=packaging.version.Version("1.0.0"),
+                    ),
+                    Package(
+                        filename="ghpypi-1.0.0.tar.gz",
+                        url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.0/ghpypi-1.0.0.tar.gz",
+                        sha256="fa6dfbe92d7b150b788da980d53f07e6e84c4079118783d5905a72cc9b636ba3",
+                        uploaded_at=datetime(2021, 12, 25, 6, 16, 9),
+                        uploaded_by="github-actions[bot]",
+                        name="ghpypi",
+                        version=packaging.version.Version("1.0.0"),
+                    ),
+                },
             },
-        },
+        ),
     ),
-))
+)
 def test_create_packages(artifacts, packages):
     assert ghpypi.create_packages(artifacts) == packages
 
 
-@pytest.mark.parametrize("artifact", (
-    Artifact(
-        filename="",
-        url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-        sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-        uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-        uploaded_by="github-actions[bot]",
+@pytest.mark.parametrize(
+    "artifact",
+    (
+        Artifact(
+            filename="",
+            url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+            sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+            uploaded_by="github-actions[bot]",
+        ),
+        Artifact(
+            filename="lol",
+            url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+            sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+            uploaded_by="github-actions[bot]",
+        ),
+        Artifact(
+            filename="lol-sup",
+            url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+            sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+            uploaded_by="github-actions[bot]",
+        ),
+        Artifact(
+            filename="-20160920.193125.zip",
+            url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+            sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+            uploaded_by="github-actions[bot]",
+        ),
+        Artifact(
+            filename=".",
+            url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+            sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+            uploaded_by="github-actions[bot]",
+        ),
+        Artifact(
+            filename="..",
+            url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+            sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+            uploaded_by="github-actions[bot]",
+        ),
+        Artifact(
+            filename="/blah-2.tar.gz",
+            url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+            sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+            uploaded_by="github-actions[bot]",
+        ),
+        Artifact(
+            filename="lol-2.tar.gz/../",
+            url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+            sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+            uploaded_by="github-actions[bot]",
+        ),
     ),
-    Artifact(
-        filename="lol",
-        url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-        sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-        uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-        uploaded_by="github-actions[bot]",
-    ),
-    Artifact(
-        filename="lol-sup",
-        url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-        sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-        uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-        uploaded_by="github-actions[bot]",
-    ),
-    Artifact(
-        filename="-20160920.193125.zip",
-        url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-        sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-        uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-        uploaded_by="github-actions[bot]",
-    ),
-    Artifact(
-        filename=".",
-        url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-        sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-        uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-        uploaded_by="github-actions[bot]",
-    ),
-    Artifact(
-        filename="..",
-        url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-        sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-        uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-        uploaded_by="github-actions[bot]",
-    ),
-    Artifact(
-        filename="/blah-2.tar.gz",
-        url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-        sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-        uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-        uploaded_by="github-actions[bot]",
-    ),
-    Artifact(
-        filename="lol-2.tar.gz/../",
-        url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-        sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-        uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-        uploaded_by="github-actions[bot]",
-    ),
-))
+)
 def test_create_packages_invalid(artifact):
     with pytest.raises(ValueError):
         ghpypi.create_package(artifact)
 
 
 def test_package_json():
-    test_packages = sorted([
-        Package(
-            filename="ghpypi-1.0.1-py3-none-any.whl",
-            url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/ghpypi-1.0.1-py3-none-any.whl",
-            sha256="ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c",
-            uploaded_at=datetime(2021, 12, 25, 6, 22, 19),
-            uploaded_by="github-actions[bot]",
-            name="ghpypi",
-            version=packaging.version.Version("1.0.1"),
-        ),
-        Package(
-            filename="ghpypi-1.0.0.tar.gz",
-            url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.0/ghpypi-1.0.0.tar.gz",
-            sha256="fa6dfbe92d7b150b788da980d53f07e6e84c4079118783d5905a72cc9b636ba3",
-            uploaded_at=datetime(2021, 12, 25, 6, 16, 9),
-            uploaded_by="github-actions[bot]",
-            name="ghpypi",
-            version=packaging.version.Version("1.0.0"),
-        ),
-    ])
+    test_packages = sorted(
+        [
+            Package(
+                filename="ghpypi-1.0.1-py3-none-any.whl",
+                url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/ghpypi-1.0.1-py3-none-any.whl",
+                sha256="ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c",
+                uploaded_at=datetime(2021, 12, 25, 6, 22, 19),
+                uploaded_by="github-actions[bot]",
+                name="ghpypi",
+                version=packaging.version.Version("1.0.1"),
+            ),
+            Package(
+                filename="ghpypi-1.0.0.tar.gz",
+                url="https://github.com/paullockaby/ghpypi/releases/download/v1.0.0/ghpypi-1.0.0.tar.gz",
+                sha256="fa6dfbe92d7b150b788da980d53f07e6e84c4079118783d5905a72cc9b636ba3",
+                uploaded_at=datetime(2021, 12, 25, 6, 16, 9),
+                uploaded_by="github-actions[bot]",
+                name="ghpypi",
+                version=packaging.version.Version("1.0.0"),
+            ),
+        ]
+    )
     package_json = ghpypi.get_package_json(test_packages)
     assert package_json["info"] == {
         "name": "ghpypi",
@@ -463,7 +522,9 @@ def test_package_json():
     }
     assert package_json["urls"] == [
         {
-            "digests": {"sha256": "ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c"},
+            "digests": {
+                "sha256": "ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c"
+            },
             "filename": "ghpypi-1.0.1-py3-none-any.whl",
             "url": "https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/ghpypi-1.0.1-py3-none-any.whl",
         },
@@ -499,13 +560,15 @@ def test_strings():
 
 def test_sorting():
     test_packages = [
-        ghpypi.create_package(ghpypi.Artifact(
-            filename=filename,
-            url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
-            sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-            uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
-            uploaded_by="github-actions[bot]",
-        ))
+        ghpypi.create_package(
+            ghpypi.Artifact(
+                filename=filename,
+                url="http://example.com/org/repo/releases/download/xxx/foobar.whl",
+                sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
+                uploaded_by="github-actions[bot]",
+            )
+        )
         for filename in (
             "fluffy-server-1.2.0.tar.gz",
             "fluffy_server-1.1.0-py2.py3-none-any.whl",
@@ -572,7 +635,7 @@ def test_create_artifacts_no_digest():
     for asset in assets:
         responses.get(
             asset["browser_download_url"],  # when we request this url
-            asset_data,                     # return this data
+            asset_data,  # return this data
         )
 
     results = list(ghpypi.create_artifacts(assets))
@@ -618,11 +681,16 @@ def test_create_artifacts_digest():
     ]
 
     # this is what all of our responses will contain
-    asset_data = b"\n".join([
-        b"fa6dfbe92d7b150b788da980d53f07e6e84c4079118783d5905a72cc9b636ba3 ghpypi-1.0.1.tar.gz",
-        b"ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c ghpypi-1.0.1-py3-none-any.whl",
-    ])
-    responses.get("https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/sha256sum.txt", asset_data)
+    asset_data = b"\n".join(
+        [
+            b"fa6dfbe92d7b150b788da980d53f07e6e84c4079118783d5905a72cc9b636ba3 ghpypi-1.0.1.tar.gz",
+            b"ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c ghpypi-1.0.1-py3-none-any.whl",
+        ]
+    )
+    responses.get(
+        "https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/sha256sum.txt",
+        asset_data,
+    )
 
     results = list(ghpypi.create_artifacts(assets))
     assert results == [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,7 +89,9 @@ def test_guess_name_version_from_filename(file_name: str, name: str, version: st
     ),
 )
 def test_guess_name_version_from_filename_only_name(
-    file_name: str, name: str, version: str
+    file_name: str,
+    name: str,
+    version: str,
 ):
     """Broken version check tests.
     The real important thing is to be able to parse the name, but it's nice if
@@ -122,10 +124,12 @@ def test_load_repositories(tmp_path: PosixPath):
     tmp_data.write_text(
         """
 
+        # below this is a blank line
+
         # this is a comment
         foo/bar
         baz/bat
-    """
+    """,
     )
 
     tmp_data_path = str(tmp_data)
@@ -235,7 +239,7 @@ def test_get_artifacts(mocker: MockerFixture):
         spec=github.Repository.Repository,
         **{
             "get_releases.return_value": [],
-        }
+        },
     )
     mocker.patch("github.MainClass.Github.get_repo", return_value=mock_get_repo)
     releases = list(ghpypi.get_artifacts(token, repository))
@@ -254,10 +258,10 @@ def test_get_artifacts(mocker: MockerFixture):
                     spec=github.GitRelease.GitRelease,
                     **{
                         "raw_data": {},
-                    }
+                    },
                 ),
             ],
-        }
+        },
     )
     mocker.patch("github.MainClass.Github.get_repo", return_value=mock_get_repo)
     releases = list(ghpypi.get_artifacts(token, repository))
@@ -274,10 +278,10 @@ def test_get_artifacts(mocker: MockerFixture):
                     spec=github.GitRelease.GitRelease,
                     **{
                         "raw_data": {"assets": []},
-                    }
+                    },
                 ),
             ],
-        }
+        },
     )
     mocker.patch("github.MainClass.Github.get_repo", return_value=mock_get_repo)
     releases = list(ghpypi.get_artifacts(token, repository))
@@ -513,7 +517,7 @@ def test_package_json():
                 name="ghpypi",
                 version=packaging.version.Version("1.0.0"),
             ),
-        ]
+        ],
     )
     package_json = ghpypi.get_package_json(test_packages)
     assert package_json["info"] == {
@@ -523,7 +527,7 @@ def test_package_json():
     assert package_json["urls"] == [
         {
             "digests": {
-                "sha256": "ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c"
+                "sha256": "ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c",
             },
             "filename": "ghpypi-1.0.1-py3-none-any.whl",
             "url": "https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/ghpypi-1.0.1-py3-none-any.whl",
@@ -567,7 +571,7 @@ def test_sorting():
                 sha256="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
                 uploaded_at=datetime(2020, 1, 1, 0, 0, 0),
                 uploaded_by="github-actions[bot]",
-            )
+            ),
         )
         for filename in (
             "fluffy-server-1.2.0.tar.gz",
@@ -685,7 +689,7 @@ def test_create_artifacts_digest():
         [
             b"fa6dfbe92d7b150b788da980d53f07e6e84c4079118783d5905a72cc9b636ba3 ghpypi-1.0.1.tar.gz",
             b"ae36bbabd6424037f716c6a78f907d6f9b058ab399a042b2c8530087beca9c3c ghpypi-1.0.1-py3-none-any.whl",
-        ]
+        ],
     )
     responses.get(
         "https://github.com/paullockaby/ghpypi/releases/download/v1.0.1/sha256sum.txt",


### PR DESCRIPTION
The folks at [pytest have seemingly decided](https://github.com/pytest-dev/pytest/issues/9217) that running lints as part of your tests is somehow an anti-pattern. While I disagree with that, I'm tired of my test harness breaking every time I upgrade either flake8 or pytest while the developers fight with each other. So here we go, moving flake8, black, and isort into a pre-commit hook. (And fwiw, I dislike black's formatting choices **a lot** but it's better than nothing.)